### PR TITLE
Fix auto-reconfiguration when settings change

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1483,7 +1483,9 @@ export async function initFromSettings(activation: boolean = false): Promise<voi
                     logger.message(e.message);
                 }
             });
-
+            if (extension.getState().configureDirty) {
+                await make.configure(make.TriggeredBy.configureAfterConfigurationChange);
+            }
             if (telemetryProperties && util.hasProperties(telemetryProperties)) {
                 telemetry.logEvent("settingsChanged", telemetryProperties);
             }


### PR DESCRIPTION
When editting settings.json to alter a configuration like makeArgs, the configuration should be refreshed (new dry-run with the new args).

This commit implements this re-configuration.