### PR TITLE
Filter out irrelevant automake build targets

### DIFF
--- a/src/make.ts
+++ b/src/make.ts
@@ -756,8 +756,47 @@ async function parseTargets(progress: vscode.Progress<{}>, cancel: vscode.Cancel
         progress.report({ increment: 1, message: status + ((recursive) ? "(recursive)" : "") });
     };
 
+    // Avoid pushing targets that are automake internal-use targets,
+    // or not build targets (eg dist-*)
+    let automake_intermediate_targts: string[] = [
+        "^cscopelist$",
+        "^distclean$",
+        // "^dist$",
+        "^ID$",
+        "^GTAGS$",
+        "^TAGS$",
+        "^CTAGS$",
+        "^tags$",
+        "^ctags$",
+        "^cscope$",
+        "^cscope.files$",
+        "^installdirs$",
+        "^installcheck$",
+        "^distcleancheck$",
+        "^distuninstallcheck$",
+        "^distcheck$",
+        "^mostlyclean$",
+        "^maintainer-clean-generic$",
+        "^mostlyclean-generic$",
+        "^clean-cscope$",
+        "^clean$",
+        "^distdir$",
+        "^am--refresh$",
+        "^stamp-h1$",
+        "^dist-",
+        "^uninstall-",
+        "^install-",
+        "^maintainter-",
+        "^distclean-",
+        "-am$",
+        "-recursive$",
+        "Makefile.in$",
+    ];
+    var automake_patterns = new RegExp(automake_intermediate_targts.join('|'));
+
     let onFoundTarget: any = (target: string): void => {
-        targets.push(target);
+        if (!automake_patterns.test(target))
+            targets.push(target);
     };
 
     let retc: number = await parser.parseTargets(cancel, dryRunOutput, onStatus, onFoundTarget);


### PR DESCRIPTION
Makefiles generated by automake include a number of targets intended for internal use, and other convenience targets which are not productive build targets. (eg, *-am, *-recursive, maintainer-clean, installchecks, etc)

The full list of available targets would frustrate a productivity-inclined user.

Some rarely used, but useful targets are kept, such as:
- install
- uninstall
- config.status, Makefile, maintainer-clean
- check, distcheck
- dist
- html, pdf, dvi

In the future, a tiered selection could be implemented, where the available targets are classified as primary, secondary and all, if automake's capabilities need to be fully exposed by the makefile tool extension. Such a selection may avoid frustration while still making it possible to select rarely used targets.

This commit implements a filter to remove targets which are not suitable for inclusion in the list of available targets for selection.