### PR TITLE
Fix automake infinite loop

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -23,7 +23,7 @@
    "makefile-tools.configuration.makefile.makePath.description": "The path to the make tool",
    "makefile-tools.configuration.makefile.configurations.description": "The user defined makefile configurations",
    "makefile-tools.configuration.makefile.configurations.name.description": "The name of the makefile configuration",
-   "makefile-tools.configuration.makefile.configurations.makefilePath.description": "File path to the makefile",
+   "makefile-tools.configuration.makefile.configurations.makefilePath.description": "File path to the makefile. Defaults to 'Makefile'",
    "makefile-tools.configuration.makefile.configurations.makePath.description": "File path to the make command",
    "makefile-tools.configuration.makefile.configurations.makeDirectory.description": "Folder path passed to make via the -C switch",
    "makefile-tools.configuration.makefile.configurations.makeArgs.description": "Arguments to pass to the make command",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -194,35 +194,37 @@ async function readMakePath(): Promise<void> {
     }
 }
 
-let makefilePath: string | undefined;
-export function getMakefilePath(): string | undefined { return makefilePath; }
-export function setMakefilePath(path: string): void { makefilePath = path; }
+let makefilePath: string = "Makefile";
+export function getMakefilePath(): string { return makefilePath; }
+export function setMakefilePath(path: string = "Makefile"): void { makefilePath = path; }
 // Read the full path to the makefile if defined in settings.
 // It represents a default to look for if no other makefile is already provided
 // in makefile.configurations.makefilePath.
 // TODO: validate and integrate with "-f [Makefile]" passed in makefile.configurations.makeArgs.
 async function readMakefilePath(): Promise<void> {
-    makefilePath = await util.getExpandedSetting<string>("makefilePath");
-    if (!makefilePath) {
+    let makefilePathSetting: string | undefined = await util.getExpandedSetting<string>("makefilePath");
+    if (!makefilePathSetting) {
         logger.message("No path to the makefile is defined in the settings file.");
+        setMakefilePath();
     } else {
-        makefilePath = util.resolvePathToRoot(makefilePath);
+        setMakefilePath(makefilePathSetting);
     }
 }
 
 let makeDirectory: string | undefined;
 export function getMakeDirectory(): string | undefined { return makeDirectory; }
-export function setMakeDirectory(dir: string): void { makeDirectory = dir; }
+export function setMakeDirectory(dir: string = ''): void { makeDirectory = dir; }
 // Read the make working directory path if defined in settings.
 // It represents a default to look for if no other makeDirectory is already provided
 // in makefile.configurations.makeDirectory.
 // TODO: validate and integrate with "-C [DIR_PATH]" passed in makefile.configurations.makeArgs.
 async function readMakeDirectory(): Promise<void> {
-    makeDirectory = await util.getExpandedSetting<string>("makeDirectory");
-    if (!makeDirectory) {
+    let makeDirectorySetting: string | undefined = await util.getExpandedSetting<string>("makeDirectory");
+    if (!makeDirectorySetting) {
         logger.message("No folder path to the makefile is defined in the settings file.");
+        setMakeDirectory();
     } else {
-      makeDirectory = util.resolvePathToRoot(makeDirectory);
+        setMakeDirectory(makeDirectorySetting);
     }
 }
 
@@ -806,7 +808,7 @@ export async function getCommandForConfiguration(configuration: string | undefin
             }
         }
 
-        if (!util.checkFileExistsSync(configurationMakefile)) {
+        if (!util.checkFileExistsSync(util.resolvePathToRoot(configurationMakefile))) {
             logger.message("The makefile entry point was not found. " +
                 "Make sure it exists at the location defined by makefile.makefilePath, makefile.configurations[].makefilePath, " +
                 "makefile.makeDirectory, makefile.configurations[].makeDirectory" +
@@ -1305,9 +1307,6 @@ export async function initFromSettings(activation: boolean = false): Promise<voi
 
             subKey = "makefilePath";
             let updatedMakefilePath : string | undefined = await util.getExpandedSetting<string>(subKey);
-            if (updatedMakefilePath) {
-                updatedMakefilePath = util.resolvePathToRoot(updatedMakefilePath);
-            }
             if (updatedMakefilePath !== makefilePath) {
                 // A change in makefile.makefilePath should trigger an IntelliSense update
                 // only if the extension is not currently reading from a build log.
@@ -1319,9 +1318,6 @@ export async function initFromSettings(activation: boolean = false): Promise<voi
 
             subKey = "makeDirectory";
             let updatedMakeDirectory : string | undefined = await util.getExpandedSetting<string>(subKey);
-            if (updatedMakeDirectory) {
-                updatedMakeDirectory = util.resolvePathToRoot(updatedMakeDirectory);
-            }
             if (updatedMakeDirectory !== makeDirectory) {
                 // A change in makefile.makeDirectory should trigger an IntelliSense update
                 // only if the extension is not currently reading from a build log.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -936,24 +936,22 @@ export async function readMakefileConfigurations(): Promise<void> {
 // Last target picked from the set of targets that are run by the makefiles
 // when building for the current configuration.
 // Saved into the settings storage. Also reflected in the configuration status bar button
-let currentTarget: string | undefined;
-export function getCurrentTarget(): string | undefined { return currentTarget; }
-export function setCurrentTarget(target: string | undefined): void { currentTarget = target; }
+// Assume the well-known "all" target for the default goal
+let currentTarget: string = "all";
+export function getCurrentTarget(): string { return currentTarget; }
+// Set the current target, or 'all' if none was given
+export function setCurrentTarget(target: string = "all"): void { currentTarget = target; }
 
 // Read current target from workspace state, update status bar item
 function readCurrentTarget(): void {
     let buildTarget : string | undefined = extension.getState().buildTarget;
+    setCurrentTarget(buildTarget);
     if (!buildTarget) {
-        logger.message("No target defined in the workspace state. Assuming 'Default'.");
-        statusBar.setTarget("Default");
-        // If no particular target is defined in settings, use 'Default' for the button
-        // but keep the variable empty, to not append it to the make command.
-        currentTarget = "";
+        logger.message(`No target defined in the workspace state. Assuming '${currentTarget}'.`);
     } else {
-        currentTarget = buildTarget;
         logger.message(`Reading current build target "${currentTarget}" from the workspace state.`);
-        statusBar.setTarget(currentTarget);
     }
+    statusBar.setTarget(currentTarget);
 }
 
 let configureOnOpen: boolean | undefined;

--- a/src/make.ts
+++ b/src/make.ts
@@ -467,7 +467,11 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
         makeArgs.push("--question");
         logger.messageNoCR("Generating targets information with command: ");
     } else {
+        const makefilePath :string = configuration.getMakefilePath();
         makeArgs.push("--dry-run");
+        makeArgs.push(`--assume-old=${makefilePath}`);
+        makeArgs.push(makefilePath);
+        makeArgs.push("AM_MAKEFLAGS=--assume-old=Makefile Makefile");
 
         // If this is not a clean configure, remove --always-make from the arguments list.
         // We need to have --always-make in makefile.dryrunSwitches and remove it for not clean configure

--- a/src/make.ts
+++ b/src/make.ts
@@ -446,17 +446,6 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
     // Continue with the make dryrun invocation
     let makeArgs: string[] = [];
 
-    // Prepend the target to the arguments given in the makefile.configurations object,
-    // unless we want to parse for the full set of available targets.
-    if (forTargets) {
-        makeArgs.push("all");
-    } else {
-        let currentTarget: string | undefined = configuration.getCurrentTarget();
-        if (currentTarget) {
-            makeArgs.push(currentTarget);
-        }
-    }
-
     // Include all the make arguments defined in makefile.configurations.makeArgs
     makeArgs = makeArgs.concat(configuration.getConfigurationMakeArgs());
 
@@ -491,6 +480,9 @@ export async function generateParseContent(progress: vscode.Progress<{}>,
                 makeArgs.push(sw);
             }
         });
+
+        // Append the target to the arguments given in the makefile.configurations object
+        makeArgs.push(configuration.getCurrentTarget());
 
         logger.messageNoCR(`Generating ${getConfigureIsInBackground() ? "in the background a new " : ""}configuration cache with command: `);
     }

--- a/src/test/fakeSuite/extension.test.ts
+++ b/src/test/fakeSuite/extension.test.ts
@@ -64,7 +64,6 @@ suite('Fake dryrun parsing', /*async*/() => {
       await vscode.workspace.getConfiguration("makefile").update("launchConfigurations", undefined);
       configuration.setCurrentLaunchConfiguration(undefined);
       configuration.setCurrentMakefileConfiguration("Default");
-      configuration.setCurrentTarget(undefined);
       configuration.initFromState();
       await configuration.initFromSettings();
 
@@ -118,7 +117,6 @@ suite('Fake dryrun parsing', /*async*/() => {
          await vscode.workspace.getConfiguration("makefile").update("launchConfigurations", undefined);
          configuration.setCurrentLaunchConfiguration(undefined);
          configuration.setCurrentMakefileConfiguration("Default");
-         configuration.setCurrentTarget(undefined);
          configuration.initFromState();
          await configuration.initFromSettings();
    
@@ -173,7 +171,6 @@ suite('Fake dryrun parsing', /*async*/() => {
          await vscode.workspace.getConfiguration("makefile").update("launchConfigurations", undefined);
          configuration.setCurrentLaunchConfiguration(undefined);
          configuration.setCurrentMakefileConfiguration("Default");
-         configuration.setCurrentTarget(undefined);
          configuration.initFromState();
          await configuration.initFromSettings();
 
@@ -250,7 +247,6 @@ suite('Fake dryrun parsing', /*async*/() => {
          await vscode.workspace.getConfiguration("makefile").update("launchConfigurations", undefined);
          configuration.setCurrentLaunchConfiguration(undefined);
          configuration.setCurrentMakefileConfiguration("Default");
-         configuration.setCurrentTarget(undefined);
          configuration.initFromState();
          await configuration.initFromSettings();
    
@@ -312,7 +308,6 @@ suite('Fake dryrun parsing', /*async*/() => {
          await vscode.workspace.getConfiguration("makefile").update("launchConfigurations", undefined);
          configuration.setCurrentLaunchConfiguration(undefined);
          configuration.setCurrentMakefileConfiguration("Default");
-         configuration.setCurrentTarget(undefined);
          configuration.initFromState();
          await configuration.initFromSettings();
    
@@ -374,7 +369,6 @@ suite('Fake dryrun parsing', /*async*/() => {
          await vscode.workspace.getConfiguration("makefile").update("launchConfigurations", undefined);
          configuration.setCurrentLaunchConfiguration(undefined);
          configuration.setCurrentMakefileConfiguration("Default");
-         configuration.setCurrentTarget(undefined);
          configuration.initFromState();
          await configuration.initFromSettings();
    
@@ -434,7 +428,6 @@ suite('Fake dryrun parsing', /*async*/() => {
       await vscode.workspace.getConfiguration("makefile").update("launchConfigurations", undefined);
       configuration.setCurrentLaunchConfiguration(undefined);
       configuration.setCurrentMakefileConfiguration("Default");
-      configuration.setCurrentTarget(undefined);
       configuration.initFromState();
       await configuration.initFromSettings();
 
@@ -476,7 +469,6 @@ suite('Fake dryrun parsing', /*async*/() => {
       await vscode.workspace.getConfiguration("makefile").update("launchConfigurations", undefined);
       configuration.setCurrentLaunchConfiguration(undefined);
       configuration.setCurrentMakefileConfiguration("Default");
-      configuration.setCurrentTarget(undefined);
       configuration.initFromState();
       await configuration.initFromSettings();
 


### PR DESCRIPTION
When --dry-running autoconf projects, the default make invocation flags, along causes the dry-run process to enter an infinite loop where the Makefile is updated, by running config.status, which requires reconfiguration.

### The problem ###
The infinite loop when dry-running autoconf projects is due to `GNU Make`'s documented behaviour. It's not a bug, or version-specific behaviour:

1. GNU Make remakes files makefiles unconditionally (defined as files it reads rules from, eg, given a statement "include blah.inc", the file `blah.inc` is a "makefile"). [Remaking Makefiles](https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html) says "*`--dry-run` does not prevent updating of makefiles, because an out-of-date makefile would result in the wrong output for other targets*"

2. Automake creates rules for updating the Makefile when `Makefile.am` changes, and when `configure.ac` changes.

3. In recursive builds, when make spawns a sub-make process, it does not pass "`--assume-old`" arguments to child make via the `MAKEFLAGS` mechanism. This is described in [Communicating Options to a Sub-make](https://www.gnu.org/software/make/manual/html_node/Options_002fRecursion.html)

Together, these three behaviours guarantee that an autoconf+automake project will end up in an infinite loop when "`--dry-run`" as the vscode "Makefile Tools" extension does by default when projects are loaded.

### Solution ###
The solution is to change the command line options as follows (`settings.json` excerpt):
```json
"makefile.dryrunSwitches": [
        "--always-make",
        "--print-directory",
        "--dry-run",
        "--assume-old=Makefile",
        "Makefile",
        "all",
        "AM_MAKEFLAGS=--assume-old=Makefile Makefile"
],
```
If using the GUI, each of these strings must appear on one line. Specifically, `AM_MAKEFLAGS=--assume-old=Makefile Makefile` is one argument. In a bash command line, this would be quoted like `AM_MAKEFLAGS="--assume-old=Makefile Makefile"`

### Explanation ###

The `--assume-old=Makefile` means the file named 'Makefile', which is also a target, will not be considered for remake, in spite of `--always-make`, per [Avoiding Compilation](https://www.gnu.org/software/make/manual/html_node/Avoiding-Compilation.html).

Since the file `Makefile` is also a file (ie, used to read rules from), it would be re-made in spite of "--dry-run". This behaviour is overriden by specifying `Makefile` as a target, in addition to `all`, as documented in [Remaking Makefiles](https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html): "*on occasion you might actually wish to prevent updating of even the makefiles. You can do this by specifying the makefiles as goals in the command line as well as specifying them as makefiles. When the makefile name is specified explicitly as a goal, the options ‘-t’ and so on do apply to them.*"

Since on recursive builds the `--assume-old` argument would not be passed to the sub-make via make's own `MAKEFLAGS` environment variable mechanism, the `AM_MAKEFLAGS` variable is used to perform override this behaviour. This works because automake projects add the value of this variable on every make invocation.

**Note 1.** If your project defines the `AM_MAKEFLAGS` variable in Makefile.am, you'll need to adjust it to include the needed `--assume-old` incantation. One way would be:

```Makefile
AM_MAKEFLAGS="--project-specific-make-flags $(DRYRUN_MAKEFLAGS)"
```

Then, use use `DRYRUN_MAKEFLAGS="--assume-old=Makefile Makefile"` in `settings.json`.

**Note 2.** Which of the `settings.json` files you put the "makefile.dryrunSwitches" settings matters. If you work on autoconf as well as cmake projects, you might want it in each project's `settings.json`. I have it set at the user level, as I work on very few cmake projects, and then I can override in at the project level.

Marked WIP because of these issues:
1. adding "all" as a target makes the assumption that "all" is the default target, which may not be true, especially in non-automake projects.
2. The workaround for recursive sub-makes only works if automake is in use. Otherwise, another way to pass `--assume-old` to sub-makes should be found.

The problem was reported at [StackOverflow](https://stackoverflow.com/q/67828011/7859025), and this is my solution to that question.

This commit changes the default `makefile.dryrunSwitches` flags as documented above.

Originally proposed upstream as microsoft#500